### PR TITLE
Avoid pow() when the base is zero

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -179,7 +179,7 @@ impl Analysis<Math> for ConstantFold {
             }
             Math::Neg(a) => Some(-x(a)?.clone()),
             Math::Pow([a, b]) => {
-                if x(b)?.is_integer() {
+                if x(b)?.is_integer() && (!x(a)?.is_zero() || x(b)? > &Ratio::zero()) {
                     Some(Pow::pow(x(a)?, x(b)?.to_integer()))
                 } else {
                     None


### PR DESCRIPTION
Right now we can get crashes by attempting to compute `(pow 0 -1)` in the Egg constant folder. This PR avoids these computations.