### PR TITLE
Use regexp for platform instead

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,10 +5,11 @@
 
 (define pkg-desc "Racket bindings for simplifying math expressions using egg")
 
+; Herbie Dockerfile uses 'x86_64-linux-natipkg'
 (define deps
-  '(("egg-herbie-windows" #:platform "win32\\x86_64" #:version "1.5")
-    ("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.5")
-    ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.5")))
+  '(("egg-herbie-windows" #:platform #rx"win32\\x86_64*" #:version "1.5")
+    ("egg-herbie-osx" #:platform #rx"x86_64-macosx*" #:version "1.5")
+    ("egg-herbie-linux" #:platform #rx"x86_64-linux*" #:version "1.5")))
 
 (define pkg-authors
   `("Oliver Flatt"))


### PR DESCRIPTION
This PR changes the platform name from strings to regular expressions. The Docker image in Herbie technically runs on a different platform called `x86_64-linux-natipkg` while `egg-herbie` only supports `x86_64-linux`, `x86_64-osx`, and `win32\\x86_64`. This should finally make Docker use `egg-herbie`!