### PR TITLE
Second attempt at fixing deps

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,11 +5,15 @@
 
 (define pkg-desc "Racket bindings for simplifying math expressions using egg")
 
-; Herbie Dockerfile uses 'x86_64-linux-natipkg'
 (define deps
-  '(("egg-herbie-windows" #:platform #rx"win32\\x86_64*" #:version "1.5")
-    ("egg-herbie-osx" #:platform #rx"x86_64-macosx*" #:version "1.5")
-    ("egg-herbie-linux" #:platform #rx"x86_64-linux*" #:version "1.5")))
+  ; ("egg-herbie-osx" #:platform "i386-macosx" #:version "1.5")
+  ("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.5")
+  ; ("egg-herbie-osx" #:platform "ppc-macosx" #:version "1.5")
+  ; ("egg-herbie-osx" #:platform "aarch64-macosx" #:version "1.5")
+  ; ("egg-herbie-windows" #:platform "win32\\i386" #:version "1.5")
+  ("egg-herbie-windows" #:platform "win32\\x86_64" #:version "1.5")
+  ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.5")
+  ("egg-herbie-linux" #:platform "x86_64-linux-natipkg" #:version "1.5"))   ; Dockerfile
 
 (define pkg-authors
   `("Oliver Flatt"))

--- a/info.rkt
+++ b/info.rkt
@@ -6,14 +6,11 @@
 (define pkg-desc "Racket bindings for simplifying math expressions using egg")
 
 (define deps
-  ; ("egg-herbie-osx" #:platform "i386-macosx" #:version "1.5")
-  ("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.5")
-  ; ("egg-herbie-osx" #:platform "ppc-macosx" #:version "1.5")
-  ; ("egg-herbie-osx" #:platform "aarch64-macosx" #:version "1.5")
-  ; ("egg-herbie-windows" #:platform "win32\\i386" #:version "1.5")
-  ("egg-herbie-windows" #:platform "win32\\x86_64" #:version "1.5")
-  ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.5")
-  ("egg-herbie-linux" #:platform "x86_64-linux-natipkg" #:version "1.5"))   ; Dockerfile
+  '(("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.5")
+    ("egg-herbie-windows" #:platform "win32\\x86_64" #:version "1.5")
+    ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.5")
+    ("egg-herbie-linux" #:platform "x86_64-linux-natipkg" #:version "1.5")))   ; Dockerfile
 
 (define pkg-authors
-  `("Oliver Flatt"))
+  `("Oliver Flatt"
+    "Brett Saiki"))


### PR DESCRIPTION
This PR (actually) fixes platform dependency issues. We support 4 platforms for egg-herbie, the last of which is for the Dockerfile.
 - ("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.5")
 - ("egg-herbie-windows" #:platform "win32\\\\x86_64" #:version "1.5")
 -  ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.5")
 -  ("egg-herbie-linux" #:platform "x86_64-linux-natipkg" #:version "1.5"))